### PR TITLE
Add packaging for Sailfish OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+p7zip
+=====
+p7zip is a port of 7z.exe and 7za.exe for POSIX systems like Unix.
+
+This repository contains the source code of the p7zip package for
+the Sailfish OS.
+
+License
+-------
+p7zip is open-source and licensed under [LGPLv2.1](https://opensource.org/licenses/LGPL-2.1).
+The RAR support uses the [UnRAR](https://fedoraproject.org/wiki/Licensing:Unrar)
+license (not used on the Sailfish OS).
+

--- a/p7zip.pro
+++ b/p7zip.pro
@@ -1,0 +1,20 @@
+TEMPLATE = subdirs
+SUBDIRS = 7z_ \
+          7za \
+          7zr \
+          Format7zFree \
+          # rar \ // Disabled for now
+          Lzham
+
+BASE_DIR = src/CPP/7zip/QMAKE/
+7z_.subdir = $$BASE_DIR/7z_
+7z_.target = sub-7z_
+7zr.subdir = $$BASE_DIR/7zr
+7za.subdir = $$BASE_DIR/7za
+Format7zFree.subdir = $$BASE_DIR/Format7zFree
+Format7zFree.target = sub-Format7zFree
+Lzham.subdir = $$BASE_DIR/Lzham
+Lzham.target = sub-Lzham
+
+7z_.depends = sub-Format7zFree sub-Lzham
+

--- a/p7zip.pro
+++ b/p7zip.pro
@@ -18,3 +18,8 @@ Lzham.target = sub-Lzham
 
 7z_.depends = sub-Format7zFree sub-Lzham
 
+scripts.files = scripts/*
+scripts.path = /usr/bin
+
+INSTALLS += scripts
+

--- a/rpm/p7zip.spec
+++ b/rpm/p7zip.spec
@@ -1,0 +1,58 @@
+Name: p7zip
+
+Summary: 7-zip file archiver (7zr)
+Version: 16.02
+Release: 1
+Group: Applications/Archiving
+License: LGPLv2.1
+Source0: %{name}-%{version}.tar.bz2
+BuildRequires: pkgconfig(Qt5Core)
+
+%description
+%{summary}. 7zr is a "light-version" of 7za that only handles 7z archives.
+
+%package full
+Summary: 7-zip file archiver (7z, 7za)
+Requires(post): /sbin/ldconfig
+Requires(postun): /sbin/ldconfig
+
+%description full
+%{summary}. 7z and 7za are the full versions of the 7-Zip executables. They
+support 7z, ZIP, CAB, ARJ, GZIP, BZIP2, TAR, CPIO, RPM and DEB archives.
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+
+%qmake5
+
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+
+%qmake5_install
+
+# Make all scripts in bindir executable
+chmod 755 %{buildroot}%{_bindir}/*
+
+%post full -p /sbin/ldconfig
+
+%postun full -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/7zr
+%dir %{_libexecdir}/p7zip
+%{_libexecdir}/p7zip/7zr
+
+%files full
+%defattr(-,root,root,-)
+%{_bindir}/7za
+%{_bindir}/7z
+%dir %{_libexecdir}/p7zip
+%{_libexecdir}/p7zip/7za
+%{_libexecdir}/p7zip/7z
+%{_libexecdir}/p7zip/lib*.so*
+

--- a/scripts/7z
+++ b/scripts/7z
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/libexec/p7zip/7z "$@"

--- a/scripts/7za
+++ b/scripts/7za
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/libexec/p7zip/7za "$@"

--- a/scripts/7zr
+++ b/scripts/7zr
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/libexec/p7zip/7zr "$@"

--- a/src/CPP/7zip/Archive/7z/7zIn.cpp
+++ b/src/CPP/7zip/Archive/7z/7zIn.cpp
@@ -1097,7 +1097,8 @@ HRESULT CInArchive::ReadAndDecodePackedStreams(
       if (CrcCalc(data, unpackSize) != folders.FolderCRCs.Vals[i])
         ThrowIncorrect();
   }
-  HeadersSize += folders.PackPositions[folders.NumPackStreams];
+  if (folders.PackPositions)
+      HeadersSize += folders.PackPositions[folders.NumPackStreams];
   return S_OK;
 }
 

--- a/src/CPP/7zip/Archive/Wim/WimHandler.cpp
+++ b/src/CPP/7zip/Archive/Wim/WimHandler.cpp
@@ -298,7 +298,7 @@ STDMETHODIMP CHandler::GetArchiveProperty(PROPID propID, PROPVARIANT *value)
 
       AString res;
 
-      bool numMethods = 0;
+      unsigned numMethods = 0;
       for (unsigned i = 0; i < ARRAY_SIZE(k_Methods); i++)
       {
         if (methodMask & ((UInt32)1 << i))

--- a/src/CPP/7zip/Compress/ShrinkDecoder.cpp
+++ b/src/CPP/7zip/Compress/ShrinkDecoder.cpp
@@ -121,7 +121,12 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
     {
       _stack[i++] = _suffixes[cur];
       cur = _parents[cur];
+	  if (cur >= kNumItems || i >= kNumItems)
+	  	break;
     }
+	
+	if (cur >= kNumItems || i >= kNumItems)
+		break;
     
     _stack[i++] = (Byte)cur;
     lastChar2 = (Byte)cur;

--- a/src/CPP/7zip/QMAKE/7z_/7z_.pro
+++ b/src/CPP/7zip/QMAKE/7z_/7z_.pro
@@ -109,3 +109,5 @@ SOURCES +=  \
 
 macx: LIBS += -framework CoreFoundation
 
+target.path = /usr/libexec/p7zip
+INSTALLS += target

--- a/src/CPP/7zip/QMAKE/7za/7za.pro
+++ b/src/CPP/7zip/QMAKE/7za/7za.pro
@@ -249,3 +249,5 @@ SOURCES +=  \
 
 macx: LIBS += -framework CoreFoundation
 
+target.path = /usr/libexec/p7zip
+INSTALLS += target

--- a/src/CPP/7zip/QMAKE/7zr/7zr.pro
+++ b/src/CPP/7zip/QMAKE/7zr/7zr.pro
@@ -180,3 +180,5 @@ SOURCES +=  \
 
 macx: LIBS += -framework CoreFoundation
 
+target.path = /usr/libexec/p7zip
+INSTALLS += target

--- a/src/CPP/7zip/QMAKE/Format7zFree/Format7zFree.pro
+++ b/src/CPP/7zip/QMAKE/Format7zFree/Format7zFree.pro
@@ -277,3 +277,5 @@ SOURCES +=  \
 
 macx: LIBS += -framework CoreFoundation
 
+target.path = /usr/libexec/p7zip
+INSTALLS += target

--- a/src/CPP/7zip/QMAKE/Lzham/Lzham.pro
+++ b/src/CPP/7zip/QMAKE/Lzham/Lzham.pro
@@ -61,3 +61,5 @@ SOURCES +=  \
 
 macx: LIBS += -framework CoreFoundation
 
+target.path = /usr/libexec/p7zip
+INSTALLS += target

--- a/src/makefile.glb
+++ b/src/makefile.glb
@@ -1,14 +1,14 @@
 
 RM=rm -f
 
-CFLAGS=-c -I. \
+CFLAGS+=$(CPPFLAGS) -c -I. \
 -I../../../../C \
 -I../../../../CPP/myWindows \
 -I../../../../CPP/include_windows \
 -I../../../../CPP \
 $(ALLFLAGS) $(ALLFLAGS_C)
 
-CXXFLAGS=-c -I. \
+CXXFLAGS+=$(CPPFLAGS) -c -I. \
 -I../../../../C \
 -I../../../../CPP/myWindows \
 -I../../../../CPP/include_windows \


### PR DESCRIPTION
[p7zip] Add packaging for Sailfish OS. Fixes JB#43307
[upstream] Include patches from the Fedora p7zip package
[upstream] Import p7zip version 16.02