### PR TITLE
[p7zip] Remove + from License tag. JB#56001

### DIFF
--- a/rpm/p7zip.spec
+++ b/rpm/p7zip.spec
@@ -4,7 +4,7 @@ Summary: 7-zip file archiver (7zr)
 Version: 16.02
 Release: 1
 Group: Applications/Archiving
-License: LGPLv2+
+License: LGPLv2
 Source0: %{name}-%{version}.tar.bz2
 BuildRequires: pkgconfig(Qt5Core)
 


### PR DESCRIPTION
p7zip license does not allow later versions of the license.